### PR TITLE
Fixes overflow of the description on small screens.

### DIFF
--- a/src/less/website.less
+++ b/src/less/website.less
@@ -32,8 +32,7 @@
         line-height: 1.8em;
 
         // Align with faq-page-container
-        width: @faq-page-container-width;
-        min-width: @faq-page-container-width;
+        max-width: @faq-page-container-width;
         margin: 0px auto;
         padding-left: @faq-page-padding;
         padding-right: @faq-page-padding;
@@ -69,7 +68,7 @@
 }
 
 @media (max-width: @faq-page-container-width) {
-    .description {
+    .faq-header .description {
         padding-left: 0px;
         padding-right: 0px;
     }


### PR DESCRIPTION
The description of the book overflows on smaller screens. Visit https://help.gitbook.com/ and resize your window to < 990px to see this happening. 
This pull request eliminates the overflow and aligns the description with the faq-page-container, as it is intended.