### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the theme to your book's configuration (`book.json`):
 {
     "plugins": [
         "theme-faq",
-        "-fontsettngs",
+        "-fontsettings",
         "-sharing"
     ]
 }


### PR DESCRIPTION
Just fix a little typo in the `book.json` example